### PR TITLE
链接超时与读取超时分开控制

### DIFF
--- a/xutils/src/main/java/org/xutils/http/RequestParams.java
+++ b/xutils/src/main/java/org/xutils/http/RequestParams.java
@@ -41,6 +41,7 @@ public class RequestParams extends BaseParams {
     private Executor executor; // 自定义线程池
     private Priority priority = Priority.DEFAULT; // 请求优先级
     private int connectTimeout = 1000 * 15; // 连接超时时间
+    private int readTimeout = 1000 * 15; // 读取超时时间
     private boolean autoResume = true; // 是否在下载是自动断点续传
     private boolean autoRename = false; // 是否根据头信息自动命名文件
     private int maxRetryCount = 2; // 最大请求错误重试次数
@@ -177,6 +178,14 @@ public class RequestParams extends BaseParams {
     public void setConnectTimeout(int connectTimeout) {
         if (connectTimeout > 0) {
             this.connectTimeout = connectTimeout;
+        }
+    }
+
+    public int getReadTimeout(){return readTimeout;}
+
+    public void setReadTimeout(int readTimeout){
+        if(readTimeout > 0){
+            this.readTimeout = readTimeout;
         }
     }
 

--- a/xutils/src/main/java/org/xutils/http/request/HttpRequest.java
+++ b/xutils/src/main/java/org/xutils/http/request/HttpRequest.java
@@ -133,7 +133,7 @@ public class HttpRequest extends UriRequest {
                 connection.setRequestProperty("Connection", "close");
             }
 
-            connection.setReadTimeout(params.getConnectTimeout());
+            connection.setReadTimeout(params.getReadTimeout());
             connection.setConnectTimeout(params.getConnectTimeout());
             connection.setInstanceFollowRedirects(params.getRedirectHandler() == null);
             if (connection instanceof HttpsURLConnection) {


### PR DESCRIPTION
我们项目里面主播在直播的过程中需要有间隔地上传一些行为数据和画板数据，要求进行上传的请求链接超时短一些，读写超时长一些，需要分开控制。
抱歉已经有人pull了这个request，但是他提交的代码是错误的。希望大神能在下次release的时候merge一下，我就不用把代码加到项目里面手动改啦0.0
