### PR TITLE
uri去掉final修饰，来满足一些特殊的修改uri的需求。

### DIFF
--- a/xutils/src/main/java/org/xutils/http/RequestParams.java
+++ b/xutils/src/main/java/org/xutils/http/RequestParams.java
@@ -24,7 +24,7 @@ public class RequestParams extends BaseParams {
 
     // 注解及其扩展参数
     private HttpRequest httpRequest;
-    private final String uri;
+    private String uri;
     private final String[] signs;
     private final String[] cacheKeys;
     private ParamsBuilder builder;
@@ -114,6 +114,14 @@ public class RequestParams extends BaseParams {
 
     public String getUri() {
         return TextUtils.isEmpty(buildUri) ? uri : buildUri;
+    }
+
+    public void setUri(String uri){
+        if(TextUtils.isEmpty(buildUri)){
+            this.uri = uri;
+        }else {
+            this.buildUri = uri;
+        }
     }
 
     public String getCacheKey() {


### PR DESCRIPTION
[RequestParams#uri](https://github.com/wyouflf/xUtils3/blob/master/xutils/src/main/java/org/xutils/http/RequestParams.java)
是final类型的，我们项目里面做了一个防止dns劫持的操作，需要在请求的某个过程中拿到uri并校验，发现劫持之后要把uri中的host替换成IP，并`addHeader("host","xxx.com");`，所以会要更改uri：

```
public void setUri(String uri){
        if(TextUtils.isEmpty(buildUri)){
            this.uri = uri;
        }else {
            this.buildUri = uri;
        }
    }
```

我们用post方式发送请求，buildUri可能是空的。
这个功能还是希望能封在框架里面，我们架构对xUtils的http封装的很深，改动RequestParams对我们来讲是最佳的方式。但是这个改动会破坏您的封装性，所以这里并不是希望您进行merge，而是提供一个更好的方式来处理一下，大神辛苦了~
