### PR TITLE
修复数据库cache超过maxSize时无法删除的问题

### DIFF
--- a/xutils/src/main/java/org/xutils/cache/LruDiskCache.java
+++ b/xutils/src/main/java/org/xutils/cache/LruDiskCache.java
@@ -270,13 +270,11 @@ public final class LruDiskCache {
                                 // delete cache files
                                 for (DiskCacheEntity entity : rmList) {
                                     String path = entity.getPath();
-                                    if (!TextUtils.isEmpty(path)) {
-                                        if (deleteFileWithLock(path)
-                                                && deleteFileWithLock(path + TEMP_FILE_SUFFIX)) {
-                                            // delete db entity
-                                            cacheDb.delete(entity);
-                                        }
+                                    if (!TextUtils.isEmpty(path) && !deleteFileWithLock(path)) {
+                                        deleteFileWithLock(path + TEMP_FILE_SUFFIX);
                                     }
+                                    // delete db entity
+                                    cacheDb.delete(entity);
                                 }
 
                             }
@@ -294,13 +292,11 @@ public final class LruDiskCache {
                                 // delete cache files
                                 for (DiskCacheEntity entity : rmList) {
                                     String path = entity.getPath();
-                                    if (!TextUtils.isEmpty(path)) {
-                                        if (deleteFileWithLock(path)
-                                                && deleteFileWithLock(path + TEMP_FILE_SUFFIX)) {
-                                            // delete db entity
-                                            cacheDb.delete(entity);
-                                        }
+                                    if (!TextUtils.isEmpty(path) && !deleteFileWithLock(path)) {
+                                        deleteFileWithLock(path + TEMP_FILE_SUFFIX);
                                     }
+                                    // delete db entity
+                                    cacheDb.delete(entity);
                                 }
                             }
                         }


### PR DESCRIPTION
当数据库缓存数量或者磁盘空间超过maxSize时，DiskCacheEntity的path为null，无法删除缓存数据库，从而导致数据库数量不断增大，cacheDb.selector(DiskCacheEntity.class).orderBy("lastAccess").orderBy("hits").limit(10).offset(0).findAll()查询的数量太大，while循环不完，CursorWindow溢出，内存反复被创建和回收，CPU一直被占用，造成性能浪费。