### PR TITLE
Update FileBody.java

### DIFF
--- a/xutils/src/main/java/org/xutils/http/body/FileBody.java
+++ b/xutils/src/main/java/org/xutils/http/body/FileBody.java
@@ -40,7 +40,13 @@ public class FileBody extends InputStreamBody {
 
     public static String getFileContentType(File file) {
         String filename = file.getName();
-        String contentType = HttpURLConnection.guessContentTypeFromName(filename);
+        String contentType = null;
+        try {
+          filename = Uri.encode(filename, "-![.:/,?&=]");
+          contentType = HttpURLConnection.guessContentTypeFromName(filename);
+        } catch (Exception e) {
+          LogUtil.e(e.toString());
+        }
         if (TextUtils.isEmpty(contentType)) {
             contentType = "application/octet-stream";
         } else {


### PR DESCRIPTION
[bug fix] FileBody.getFileContentType(File file) ,在文件名包含"#"字符时,出现异常,导致上传文件失败.